### PR TITLE
Correction to Clinvar-by-codon keys

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.3.0
 commit = True
 tag = False
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-bullseye
 
 # take as a command line argument, or
-ARG RELEASE=${RELEASE:-1.3.0}
+ARG RELEASE=${RELEASE:-1.2.0}
 
 RUN apt update && apt install -y \
         apt-transport-https \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-bullseye
 
 # take as a command line argument, or
-ARG RELEASE=${RELEASE:-1.2.0}
+ARG RELEASE=${RELEASE:-1.3.0}
 
 RUN apt update && apt install -y \
         apt-transport-https \

--- a/clinvarbitration/clinvar_by_codon.py
+++ b/clinvarbitration/clinvar_by_codon.py
@@ -88,12 +88,12 @@ def main(input_vcf: str, output_root: str):
         # extract the clinvar details (added in previous script)
         clinvar_allele = variant.INFO['allele_id']
         clinvar_stars = variant.INFO['gold_stars']
-        clinvar_key = f'{clinvar_allele}:{clinvar_stars}'
+        clinvar_key = f'{clinvar_allele}::{clinvar_stars}'
 
         # iterate over all missense consequences
         for csq_dict in variant_consequences(variant, header_csq):
             # add this clinvar entry in relation to the protein consequence
-            protein_key = f"{csq_dict['ensp']}:{csq_dict['protein_position']}"
+            protein_key = f"{csq_dict['ensp']}::{csq_dict['protein_position']}"
             clinvar_dict[protein_key].add(clinvar_key)
 
     # save the dictionary locally

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name='clinvarbitration',
     description='CPG ClinVar Re-interpretation',
     long_description=readme,
-    version='1.2.0',
+    version='1.3.0',
     author='Matthew Welland, CPG',
     author_email='matthew.welland@populationgenomics.org.au, cas.simons@populationgenomics.org.au',
     url='https://github.com/populationgenomics/ClinvArbitration',


### PR DESCRIPTION
# Purpose

  - Somewhere during the extraction of this process from a CPG pipeline stage into a separate codebase I slipped up. The ENSG and codon, and the ClinVar rating and number of stars should have been separated by a double `:`. That has changed, so now the Talos analyses have failed to generate PM5 results

## Proposed Changes

  - Replaces the single-colon separation with a double
  - Need to regenerate the latest data following this change

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
