### PR TITLE
Weighted-scoring

### DIFF
--- a/test/test_resummarise.py
+++ b/test/test_resummarise.py
@@ -28,4 +28,4 @@ def test_consequence_decision_path_single(
         sub = deepcopy(BASIC_SUB)
         sub.classification = con
         all_subs.append(sub)
-    assert consequence_decision(all_subs) == expected
+    assert consequence_decision(all_subs, False) == expected


### PR DESCRIPTION
# Purpose

  - For discussion.
  - As a rule (or on average?), newer submissions should carry more weight than older submissions as they are made in the context of the previous submissions and any new data available.
  - So, lets add a weighting to submissions based on their age.

## Proposed Changes

  - This PR adds a straightforward weighing strategy. It uses the existing algorithm but inflates the relative value of a submission based on recency. Submissions from the last year have a weight of `5`, the last two years `4`, three years `3`, four years `2`,  older than four years `1`
  

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
