### PR TITLE
Link correction, rearrange some words

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.4.0
+current_version = 1.5.0
 commit = True
 tag = False
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-bullseye
 
 # take as a command line argument, or
-ARG RELEASE=${RELEASE:-1.4.0}
+ARG RELEASE=${RELEASE:-1.5.0}
 
 RUN apt update && apt install -y \
         apt-transport-https \

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## motivation
 
-During the creation of [Talos](https://www.github.ocom/populationgenomics/automated-interpretation-pipeline), a tool for identifying clinically relevant variants in large cohorts, we leveraged the entries in [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/) as a contributing factor in determining pathogenicity. During development of this tool we determined that the default summaries generated in ClinVar were highly conservative; see the [table here](https://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/#agg_germline) describing the aggregate classification logic.
+During the creation of [Talos](https://www.github.com/populationgenomics/automated-interpretation-pipeline), a tool for identifying clinically relevant variants in large cohorts, we use [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/) ratings as a contributing factor in determining pathogenicity. During development of this tool we determined that the default summaries generated in ClinVar were highly conservative; see the [table here](https://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/#agg_germline) describing the aggregate classification logic.
 
 ## content
 
-This repository contains an alternative algorithm ([described here](docs/algorithm.md)) for re-visiting the ClinVar default results, generating alternative decisions which tend towards clear assignment of pathogenic/benign ratings. These ratings are not intended as a replacement of ClinVar's own decisions, but may provide value in situations where an analyst would benefit from seeing that though conflicting submissions exist, there is a bias towards either benign or pathogenic ratings.
+This repository contains an alternative algorithm ([described here](docs/algorithm.md)) for re-aggregating the individual ClinVar submissions, generating decisions which favour clear assignment of pathogenic/benign ratings instead of defaulting to 'conflicting'. These ratings are not intended as a replacement of ClinVar's own decisions, but may provide value by showing that that though conflicting submissions exist, there is a clear bias towards either benign or pathogenic ratings.
 
 ## outputs
 

--- a/clinvarbitration/resummarise_clinvar.py
+++ b/clinvarbitration/resummarise_clinvar.py
@@ -74,7 +74,7 @@ class Consequence(Enum):
 
     BENIGN = 'Benign'
     CONFLICTING = 'Conflicting'
-    PATHOGENIC = 'Pathogenic'
+    PATHOGENIC = 'Pathogenic/Likely Pathogenic'
     UNCERTAIN = 'VUS'
     UNKNOWN = 'Unknown'
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name='clinvarbitration',
     description='CPG ClinVar Re-interpretation',
     long_description=readme,
-    version='1.4.0',
+    version='1.5.0',
     author='Matthew Welland, CPG',
     author_email='matthew.welland@populationgenomics.org.au, cas.simons@populationgenomics.org.au',
     url='https://github.com/populationgenomics/ClinvArbitration',


### PR DESCRIPTION
# Purpose

  - The link to Talos/AIP was broken
  - Some of the wording was pretty... wordy, so I've simplified

## Proposed Changes

  - fixes a link
  - trims some exaggerated verbosity
  - changes "Pathogenic" in the results to "Pathogenic/Likely Pathogenic" which is more specific and truthful
    - the change from P to P/LP is going to be something Talos has to adjust to downstream 
    - relevant to https://github.com/populationgenomics/automated-interpretation-pipeline/issues/435