### PR TITLE
Correction to star summary method

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0
+current_version = 1.5.1
 commit = True
 tag = False
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-bullseye
 
 # take as a command line argument, or
-ARG RELEASE=${RELEASE:-1.5.0}
+ARG RELEASE=${RELEASE:-1.5.1}
 
 RUN apt update && apt install -y \
         apt-transport-https \

--- a/clinvarbitration/resummarise_clinvar.py
+++ b/clinvarbitration/resummarise_clinvar.py
@@ -241,12 +241,14 @@ def check_stars(subs: list[Submission]) -> int:
     """
     minimum = 0
     for sub in subs:
+        if sub.classification in (Consequence.UNCERTAIN, Consequence.UNKNOWN):
+            continue
         if sub.review_status == 'practice guideline':
-            return 4
+            minimum = 4
         if sub.review_status == 'reviewed by expert panel':
-            return 3
+            minimum = max(minimum, 3)
         if sub.review_status not in NO_STAR_RATINGS:
-            minimum = 1
+            minimum = max(minimum, 1)
 
     return minimum
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name='clinvarbitration',
     description='CPG ClinVar Re-interpretation',
     long_description=readme,
-    version='1.5.0',
+    version='1.5.1',
     author='Matthew Welland, CPG',
     author_email='matthew.welland@populationgenomics.org.au, cas.simons@populationgenomics.org.au',
     url='https://github.com/populationgenomics/ClinvArbitration',

--- a/test/test_resummarise.py
+++ b/test/test_resummarise.py
@@ -4,10 +4,68 @@ from datetime import datetime
 import pytest
 import zoneinfo
 
-from clinvarbitration.resummarise_clinvar import Consequence, Submission, consequence_decision
+from clinvarbitration.resummarise_clinvar import Consequence, Submission, consequence_decision, check_stars
 
 TIMEZONE = zoneinfo.ZoneInfo('Australia/Brisbane')
 BASIC_SUB = Submission(datetime.now(tz=TIMEZONE), 'foo', Consequence.UNKNOWN, 'review')
+
+
+def test_check_stars_none():
+    """
+    check that we always get the right number of stars!
+    """
+    # Unknown, should be skipped over
+    dud_1 = deepcopy(BASIC_SUB)
+    dud_2 = deepcopy(BASIC_SUB)
+    # Pathogenic, but has a no-star rating
+    dud_2.classification = Consequence.PATHOGENIC
+    dud_2.review_status = 'no assertion criteria provided'
+    assert check_stars([dud_1, dud_2]) == 0
+
+
+def test_check_stars_1():
+    """
+    check that we always get the right number of stars!
+    """
+    expect_1_path = deepcopy(BASIC_SUB)
+    expect_1_path.classification = Consequence.PATHOGENIC
+    assert check_stars([expect_1_path]) == 1
+    expect_1_benign = deepcopy(BASIC_SUB)
+    expect_1_benign.classification = Consequence.BENIGN
+    assert check_stars([expect_1_benign]) == 1
+    assert check_stars([expect_1_path, expect_1_benign]) == 1
+
+
+def test_check_stars_3():
+    """
+    check that we always get the right number of stars!
+    """
+    expect_1_path = deepcopy(BASIC_SUB)
+    expect_1_path.classification = Consequence.PATHOGENIC
+    expect_1_neutral = deepcopy(BASIC_SUB)
+    assert check_stars([expect_1_path, expect_1_neutral]) == 1
+    expert_panel = deepcopy(BASIC_SUB)
+    expert_panel.review_status = 'reviewed by expert panel'
+    expert_panel.classification = Consequence.PATHOGENIC
+    assert check_stars([expect_1_path, expect_1_neutral, expert_panel]) == 3
+
+
+def test_check_stars_4():
+    """
+    check that we always get the right number of stars!
+    """
+    expect_1_path = deepcopy(BASIC_SUB)
+    expect_1_path.classification = Consequence.PATHOGENIC
+    expect_1_neutral = deepcopy(BASIC_SUB)
+    assert check_stars([expect_1_path, expect_1_neutral]) == 1
+    expert_panel = deepcopy(BASIC_SUB)
+    expert_panel.review_status = 'reviewed by expert panel'
+    expert_panel.classification = Consequence.PATHOGENIC
+    assert check_stars([expect_1_path, expect_1_neutral, expert_panel]) == 3
+    practice_guideline = deepcopy(BASIC_SUB)
+    practice_guideline.review_status = 'practice guideline'
+    practice_guideline.classification = Consequence.PATHOGENIC
+    assert check_stars([expect_1_path, expect_1_neutral, expert_panel, practice_guideline]) == 4
 
 
 @pytest.mark.parametrize(

--- a/test/test_resummarise.py
+++ b/test/test_resummarise.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytest
 import zoneinfo
 
-from clinvarbitration.resummarise_clinvar import Consequence, Submission, consequence_decision, check_stars
+from clinvarbitration.resummarise_clinvar import Consequence, Submission, check_stars, consequence_decision
 
 TIMEZONE = zoneinfo.ZoneInfo('Australia/Brisbane')
 BASIC_SUB = Submission(datetime.now(tz=TIMEZONE), 'foo', Consequence.UNKNOWN, 'review')


### PR DESCRIPTION
# Purpose

  - Closes #11 
  - When we calculate the number of stars for a submission, we were considering the Uncertain/Unknown submissions. If an allele had a 0-star Pathogenic and a 1-star Uncertain, the result would be Pathogenic (due to the tie-breaking) and 1-star (from the Uncertain)

## Proposed Changes

  - When calculating Stars, we skip over Uncertain/Unknown-rated submissions
  - adds test cases to confirm all combinations

## Checklist

- [x] Related GitHub Issue created
- [x] Tests covering new change
- [x] Linting checks pass
